### PR TITLE
better support for kafka internal

### DIFF
--- a/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-events.yaml
@@ -63,6 +63,8 @@ spec:
           - --commit-batch-size {{ default "1" .Values.sentry.subscriptionConsumerEvents.commitBatchSize }}
           {{- if and (not .Values.kafka.enabled) .Values.externalKafka.topics }}
           - --topic {{ .Values.externalKafka.topics.eventsSubscriptionResults }}
+          {{- else }}
+          - --topic events-subscription-results
           {{- end }}
           {{- if and (not .Values.kafka.enabled) .Values.externalKafka.consumerGroups }}
           - --group {{ .Values.externalKafka.consumerGroups.sentrySubscription }}

--- a/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-sentry-subscription-consumer-transactions.yaml
@@ -63,6 +63,8 @@ spec:
           - --commit-batch-size {{ default "1" .Values.sentry.subscriptionConsumerTransactions.commitBatchSize }}
           {{- if and (not .Values.kafka.enabled) .Values.externalKafka.topics }}
           - --topic {{ .Values.externalKafka.topics.transactionsSubscriptionResults }}
+          {{- else }}
+          - --topic transactions-subscription-results
           {{- end }}
           {{- if and (not .Values.kafka.enabled) .Values.externalKafka.consumerGroups }}
           - --group {{ .Values.externalKafka.consumerGroups.sentrySubscription }}

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -78,9 +78,6 @@ spec:
         {{- end }}
         - --consumer-group
         - {{ .Values.externalKafka.consumerGroups.replacers | quote }}
-        {{- else }}
-        - --replacements-topic
-        - event-replacements
         {{- end }}
         - --log-level
         - {{ .Values.snuba.logging.level }}

--- a/sentry/templates/deployment-snuba-replacer.yaml
+++ b/sentry/templates/deployment-snuba-replacer.yaml
@@ -78,6 +78,9 @@ spec:
         {{- end }}
         - --consumer-group
         - {{ .Values.externalKafka.consumerGroups.replacers | quote }}
+        {{- else }}
+        - --replacements-topic
+        - event-replacements
         {{- end }}
         - --log-level
         - {{ .Values.snuba.logging.level }}

--- a/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-events.yaml
@@ -71,6 +71,11 @@ spec:
           - --result-topic={{ .eventsSubscriptionResults }}
           - --commit-log-topic={{ .commitLog }}
           {{- end }}
+          {{- else }}
+          - --topic=events
+          - --result-topic=events-subscription-results
+          - --commit-log-topic=snuba-commit-log
+          - --consumer-group=snuba-events-subscriptions-consumers
           {{- end }}
           {{- if and (not .Values.kafka.enabled) .Values.externalKafka.consumerGroups }}
           {{- with .Values.externalKafka.consumerGroups }}

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -71,6 +71,11 @@ spec:
           - --result-topic={{ .transactionsSubscriptionResults }}
           - --commit-log-topic={{ .commitLog }}
           {{- end }}
+          {{- else }}
+          - --topic=events
+          - --result-topic=events-subscription-results
+          - --commit-log-topic=snuba-commit-log
+          - --consumer-group=snuba-transactions-subscriptions-consumers
           {{- end }}
           {{- if and (not .Values.kafka.enabled) .Values.externalKafka.consumerGroups }}
           {{- with .Values.externalKafka.consumerGroups }}

--- a/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
+++ b/sentry/templates/deployment-snuba-subscription-consumer-transactions.yaml
@@ -73,8 +73,9 @@ spec:
           {{- end }}
           {{- else }}
           - --topic=events
-          - --result-topic=events-subscription-results
+          - --result-topic=transactions-subscription-results
           - --commit-log-topic=snuba-commit-log
+          - --commit-log-group=snuba-transactions-consumers
           - --consumer-group=snuba-transactions-subscriptions-consumers
           {{- end }}
           {{- if and (not .Values.kafka.enabled) .Values.externalKafka.consumerGroups }}

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -82,6 +82,9 @@ spec:
         {{- end }}
         - --consumer-group
         - {{ .Values.externalKafka.consumerGroups.transactionCommitLog | quote }}
+        {{- else }}
+        - --consumer-group
+        - snuba-transactions-consumers
         {{- end }}
         - --log-level
         - {{ .Values.snuba.logging.level }}

--- a/sentry/templates/deployment-snuba-transactions-consumer.yaml
+++ b/sentry/templates/deployment-snuba-transactions-consumer.yaml
@@ -85,6 +85,8 @@ spec:
         {{- else }}
         - --consumer-group
         - snuba-transactions-consumers
+        - --commit-log-topic
+        - snuba-commit-log
         {{- end }}
         - --log-level
         - {{ .Values.snuba.logging.level }}

--- a/sentry/templates/hooks/snuba-db-init.job.yaml
+++ b/sentry/templates/hooks/snuba-db-init.job.yaml
@@ -82,6 +82,7 @@ spec:
           value: {{ .Values.sentry.eventRetentionDays | quote }}
         - name: CLICKHOUSE_SINGLE_NODE
           value: "true"
+{{ include "sentry.snuba.env" . | indent 8 }}
 {{- if .Values.hooks.snubaInit.env }}
 {{ toYaml .Values.hooks.snubaInit.env | indent 8 }}
 {{- end }}


### PR DESCRIPTION
In this MR, I make two changes to better support for kafka internal:
 - Add missing consumer-group/topic names for added consumers. without it, some consumers raise exceptions because the argument is required and some doesn't work, because one default consumer name uses multiple times.
 - Add snuba settings to snuba-init job, It allows us to create default kafka topics with `Values.hooks.snubaInit.kafka` variable.