### PR TITLE
Fix db-check job when externalKafka hosts is array

### DIFF
--- a/sentry/templates/_helper.tpl
+++ b/sentry/templates/_helper.tpl
@@ -363,7 +363,7 @@ Set Kafka Confluent port
 {{- define "sentry.kafka.port" -}}
 {{- if and (.Values.kafka.enabled) (.Values.kafka.service.port) -}}
 {{- .Values.kafka.service.port }}
-{{- else if and (.Values.externalKafka) (not (kindIs "slice" .Values.externalKafka.hosts)) -}}
+{{- else if .Values.externalKafka -}}
 {{ required "A valid .Values.externalKafka.port is required" .Values.externalKafka.port }}
 {{- end -}}
 {{- end -}}

--- a/sentry/templates/hooks/sentry-db-check.job.yaml
+++ b/sentry/templates/hooks/sentry-db-check.job.yaml
@@ -106,16 +106,16 @@ spec:
                 fi
                 i=$((i+1))
               done
-              {{- else if (not (kindIs "slice" .Values.externalKafka)) }}
+              {{- else if (not (kindIs "slice" .Values.externalKafka.hosts)) }}
               KAFKA_HOST={{ .Values.externalKafka.host }}
               if ! nc -z "$KAFKA_HOST" {{ $kafkaPort }}; then
                 KAFKA_STATUS=0
                 echo "$KAFKA_HOST is not available yet"
               fi
               {{- else }}
-              {{- range $elem := .Values.externalKafka }}
-              KAFKA_HOST={{ $elem.host }}
-              if ! nc -z "$KAFKA_HOST" {{ $elem.port }}; then
+              {{- range $elem := .Values.externalKafka.hosts }}
+              KAFKA_HOST={{ $elem }}
+              if ! nc -z "$KAFKA_HOST" {{ $kafkaPort }}; then
                 KAFKA_STATUS=0
                 echo "$KAFKA_HOST is not available yet"
               fi


### PR DESCRIPTION
Current way to add multiple hosts is:
```
externalKafka:
  hosts:
     - host1
     - host2
     - ...
  port: 9092
```

so, externalKafka.hosts is slice and kafkaPort should be set also when it is slice.